### PR TITLE
Fix image border mismatch

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -245,7 +245,7 @@ body {
   object-fit: cover;
   max-width: 100%;
   max-height: 100%;
-  border-radius: 12px;
+  border-radius: 16px;
   display: block;
 }
 
@@ -495,7 +495,7 @@ body {
   max-width: 100%;
   margin: auto;
   overflow: hidden;
-  border-radius: 8px; /* To match the original design */
+  border-radius: 16px;
 }
 
 .carousel-slide {


### PR DESCRIPTION
## Summary
- ensure inner image radius matches outer wrapper
- bump carousel border radius to 16px

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859de9d6e6483288e653be7fe7f3736